### PR TITLE
Fea:提前了传送带的物品检测，降低了延迟

### DIFF
--- a/src/main/java/net/pinkcats/createlazytick/mixin/OptElement/belt/BeltTickMixin.java
+++ b/src/main/java/net/pinkcats/createlazytick/mixin/OptElement/belt/BeltTickMixin.java
@@ -60,6 +60,8 @@ public class BeltTickMixin {
     private int animal_delay = 0;
     @Unique
     private int HasItemCount = 0;
+    @Unique
+    private int LastItemListSize = 0;
 
     @Inject(method = "tick" ,at=@At("HEAD" ),cancellable = true,remap = false)
     public void tick(CallbackInfo ci) {
@@ -67,7 +69,25 @@ public class BeltTickMixin {
             return;
         }
 
-        //System.out.println("Belt "+BeltCurrentTick+"   "+BeltDelayTick);
+        BeltInventoryAccessor accessor = (BeltInventoryAccessor) this;
+        BeltInventory OrginalBeltInventory = (BeltInventory) (Object) this;
+
+        BeltBlockEntity belt = accessor.getBelt();
+        List<TransportedItemStack> toInsert = accessor.getToInsert();
+        List<TransportedItemStack> toRemove = accessor.getToRemove();
+        List<TransportedItemStack> items = accessor.getItems();
+
+        int queuedInsertions = toInsert.size();
+        int queuedRemovals = toRemove.size();
+        if (createLazyTick$drainPendingTransfers(belt, toInsert, toRemove, items)) {
+            createLazyTick$resetDelayCounters();
+        }
+
+        if (items.size() != LastItemListSize) {
+            LastItemListSize = items.size();
+            createLazyTick$resetDelayCounters();
+        }
+
         if (BeltCurrentTick >= BeltDelayTick){
             BeltCurrentTick = 0;
         } else {
@@ -77,16 +97,6 @@ public class BeltTickMixin {
                 return;}
         }
 
-
-
-        BeltInventoryAccessor accessor = (BeltInventoryAccessor) this;
-        BeltInventory OrginalBeltInventory = (BeltInventory) (Object) this;
-
-        BeltBlockEntity belt = accessor.getBelt();
-        List<TransportedItemStack>  toInsert = accessor.getToInsert();
-        List<TransportedItemStack>  toRemove = accessor.getToRemove();
-        List<TransportedItemStack> items = accessor.getItems();
-
         // Residual item for "smooth" transitions
         if (lazyClientItem != null) {
             if (lazyClientItem.locked)
@@ -95,19 +105,16 @@ public class BeltTickMixin {
                 lazyClientItem.locked = true;
         }
 
-        // Added/Removed items from previous cycle
-        if (!toInsert.isEmpty() || !toRemove.isEmpty()) {
-            toInsert.forEach(this::insert);
-            toInsert.clear();
-            items.removeAll(toRemove);
-            toRemove.clear();
-            belt.notifyUpdate();
-            //System.out.println("item removed/added");
-            BeltDelayTick = 0;
-            animal_delay = 0;
-        }
+//        System.out.println(
+//                "[LazyTick] pos=" + belt.getBlockPos()
+//                        + " delay=" + BeltDelayTick
+//                        + " cur=" + BeltCurrentTick
+//                        + " toInsert=" + queuedInsertions
+//                        + " toRemove=" + queuedRemovals
+//                        + " items=" + items.size()
+//        );
 
-        //stop
+        // stop
         if (belt.getSpeed() == 0) {
             ci.cancel();
             return;
@@ -208,7 +215,7 @@ public class BeltTickMixin {
             float nextOffset = currentItem.beltPosition + limitedMovement;
 
             if (Math.abs(limitedMovement) < 0.00001){
-                currentItem.stack.getCount();
+                stop_count = stop_count + currentItem.stack.getCount();
             }
 
 
@@ -325,18 +332,41 @@ public class BeltTickMixin {
         }
 
         else {
-            BeltDelayTick = 0;
-            animal_delay = 0;
+            createLazyTick$resetDelayCounters();
         }
 
         if (HasItemCount != count) {
             HasItemCount = count;
-            BeltDelayTick = 0;
-            animal_delay = 0;
+            createLazyTick$resetDelayCounters();
         }
 
         ci.cancel();
     }
+
+
+    @Unique
+    private boolean createLazyTick$drainPendingTransfers(BeltBlockEntity belt, List<TransportedItemStack> toInsert,
+                                                    List<TransportedItemStack> toRemove, List<TransportedItemStack> items) {
+        if (toInsert.isEmpty() && toRemove.isEmpty())
+            return false;
+
+        toInsert.forEach(this::insert);
+        toInsert.clear();
+        if (!toRemove.isEmpty()) {
+            items.removeAll(toRemove);
+            toRemove.clear();
+        }
+        belt.notifyUpdate();
+        return true;
+    }
+
+    @Unique
+    private void createLazyTick$resetDelayCounters() {
+        BeltCurrentTick = 0;
+        BeltDelayTick = 0;
+        animal_delay = 0;
+    }
+
 
 
     @Unique


### PR DESCRIPTION
原因：物品输入空转传送带后并非立即取消delay，而是需要等到下一个未被取消的tick到来，假设delay为60tick，物品需要3s中才能正常在传送带运输，在传送带和传送带相接的情况下延迟更为严重，在仓库物流中一个包裹可能会被延迟6-9s的出货时间

修改：把toinsert/remove的处理和检测的物品变化提前到cancel前了，以及一些附带小修改

效果：物品在输入后会立即被正常运输，且传送带阻塞情况下的占用同样不高
<img width="855" height="471" alt="531347946-bad94d86-4871-42b6-be57-7ce6c9d61393" src="https://github.com/user-attachments/assets/81324370-0267-4032-81bc-80bd897a0b5b" />

重新提交pr，删掉了动力锯的改动（因为都放在一个分支里面了），注释掉了print